### PR TITLE
feat: configure DistanceConfig from Profile hints

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ Here is an overview:
  * jessLryan, max elevation can now be negative
  * joe-akeem, improvements like #2158
  * JohannesPelzer, improved GPX information and various other things
+ * karololszacki, introduce `navigation_transport_mode` option for Profiles to easily set which Voice Guidance distances to use
  * karussell, one of the core developers
  * khuebner, initial turn costs support
  * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#88)

--- a/config-example.yml
+++ b/config-example.yml
@@ -30,6 +30,7 @@ graphhopper:
 
   profiles:
    - name: car
+#      navigation_transport_mode: "driving"
 #     turn_costs:
 #       vehicle_types: [motorcar, motor_vehicle]
 #       u_turn_costs: 60
@@ -39,15 +40,19 @@ graphhopper:
 #   You can use the following in-built profiles. After you start GraphHopper it will print which encoded values you'll have to add to graph.encoded_values in this config file.
 #
 #    - name: foot
+#      navigation_transport_mode: "walking"
 #      custom_model_files: [foot.json, foot_elevation.json]
 #
 #    - name: bike
+#      navigation_transport_mode: "cycling"
 #      custom_model_files: [bike.json, bike_elevation.json]
 #
 #    - name: racingbike
+#      navigation_transport_mode: "cycling"
 #      custom_model_files: [racingbike.json, bike_elevation.json]
 #
 #    - name: mtb
+#      navigation_transport_mode: "cycling"
 #      custom_model_files: [mtb.json, bike_elevation.json]
 #
 #    # See the bus.json for more details.

--- a/navigation/src/main/java/com/graphhopper/navigation/DistanceConfig.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/DistanceConfig.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.navigation;
 
+import com.graphhopper.config.Profile;
 import com.graphhopper.util.TranslationMap;
 
 import java.util.ArrayList;
@@ -29,11 +30,18 @@ import static com.graphhopper.navigation.DistanceUtils.UnitTranslationKey.*;
 public class DistanceConfig {
     final List<VoiceInstructionConfig> voiceInstructions;
     final DistanceUtils.Unit unit;
+    static final String MAPBOX_PROFILE_CYCLING = "cycling";
+    static final String MAPBOX_PROFILE_WALKING = "walking";
+    static final String MAPBOX_PROFILE_DRIVING = "driving";
+
+    public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale, Profile profile) {
+        this(unit, translationMap, locale, profile.getHints().getString("navigation_transport_mode", MAPBOX_PROFILE_DRIVING));
+    }
 
     public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale, String mapboxProfile) {
         this.unit = unit;
         switch (mapboxProfile) {
-            case "cycling":
+            case MAPBOX_PROFILE_CYCLING:
             if (unit == DistanceUtils.Unit.METRIC) {
                 voiceInstructions =  Arrays.asList(
                     new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, translationMap, locale, new int[]{150},
@@ -44,7 +52,7 @@ public class DistanceConfig {
                         new int[]{500}));
             }
             break;
-            case "walking":
+            case MAPBOX_PROFILE_WALKING:
             if (unit == DistanceUtils.Unit.METRIC) {
                 voiceInstructions =  Arrays.asList(
                     new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, translationMap, locale, new int[]{50},

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -213,7 +213,7 @@ public class NavigateResource {
                 unit = DistanceUtils.Unit.IMPERIAL;
             }
 
-            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), "driving");
+            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), graphHopper.getProfile(request.getProfile()));
             logger.info(logStr);
             return Response.ok(NavigateResponseConverter.convertFromGHResponse(ghResponse, translationMap, request.getLocale(), config)).
                     header("X-GH-Took", "" + Math.round(took * 1000)).

--- a/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
@@ -1,0 +1,37 @@
+package com.graphhopper.navigation;
+
+import com.graphhopper.config.Profile;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DistanceConfigTest {
+
+    @Test
+    public void distanceConfigTest() {
+        DistanceConfig driving = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, "driving");
+        assertEquals(4, driving.voiceInstructions.size());
+        DistanceConfig walking = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, "walking");
+        assertEquals(1, walking.voiceInstructions.size());
+        DistanceConfig cycling = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, "cycling");
+        assertEquals(1, cycling.voiceInstructions.size());
+
+
+        Profile drivingProfile = new Profile("my_car").putHint("navigation_transport_mode", "driving");
+        DistanceConfig drivingFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, drivingProfile);
+        assertEquals(4, drivingFromProfile.voiceInstructions.size());
+
+        Profile walkingProfile = new Profile("my_feet").putHint("navigation_transport_mode", "walking");
+        DistanceConfig walkingFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, walkingProfile);
+        assertEquals(1, walkingFromProfile.voiceInstructions.size());
+
+        Profile cyclingProfile = new Profile("my_bike").putHint("navigation_transport_mode", "cycling");
+        DistanceConfig cyclingFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, cyclingProfile);
+        assertEquals(1, cyclingFromProfile.voiceInstructions.size());
+
+        Profile truckProfile = new Profile("my_truck"); // no hint set, so defaults to driving
+        DistanceConfig truckCfg = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, truckProfile);
+        assertEquals(4, truckCfg.voiceInstructions.size());
+    }
+
+}


### PR DESCRIPTION
With this change, it will be easier to:

1. Set values in `DistanceConfig` from the GH Profile
2. Use that for Voice Instructions
(at different distances per profile, see https://github.com/graphhopper/graphhopper/pull/3165)
3. May be also reused for Turn Lane [support pr](https://github.com/graphhopper/graphhopper/pull/2954) 
- basically changing the call in `Router.java` to 
```java
setWithTurnLanes(request.getProfile().getHints().getString("navigation_transport_mode", "driving") == "driving")
```
and some more calls to `OSMReaderConfig::setTurnLanesProfiles`